### PR TITLE
Authentication error

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -84,9 +84,9 @@ abstract class Resource
         switch ($errorGroup) {
             case '105':
             case '360':
-                throw new TokenException($message, $code)
+                throw new TokenException($message, $code);
             default:
-                throw new ResponseException($message, $code)
+                throw new ResponseException($message, $code);
         }
     }
 


### PR DESCRIPTION
despite documentation, we are getting these 2 error codes (36004005,36004001) in case of failing in authentication

36004005 "can not find related auth record"
36004001 "rt has expired"
this needs to be excluded from other errors as it requires to be treated as TokenException