### PR TITLE
Add proxy option to Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -63,6 +63,7 @@ class Client
      * @see https://docs.guzzlephp.org/en/stable/request-options.html
      */
     protected $options;
+    protected $proxy;
 
     public const resources = [
         Shop::class,
@@ -78,7 +79,7 @@ class Client
         Supplychain::class,
     ];
 
-    public function __construct($app_key, $app_secret, $shop_id = null, $sandbox = false, $version = self::DEFAULT_VERSION, $options = [])
+    public function __construct($app_key, $app_secret, $shop_id = null, $sandbox = false, $version = self::DEFAULT_VERSION, $options = [], $proxy = null)
     {
         $this->app_key = $app_key;
         $this->app_secret = $app_secret;
@@ -86,6 +87,7 @@ class Client
         $this->sandbox = $sandbox;
         $this->version = $version;
         $this->options = $options;
+        $this->proxy = $proxy;
     }
 
     public function useSandboxMode()
@@ -188,7 +190,9 @@ class Client
             'handler' => $stack,
             'base_uri' => 'https://'.$api_domain_endpoint.'/api/',
         ], $this->options ?? []);
-
+        if ($this->proxy) {
+            $options['proxy'] = $this->proxy;
+        }
         return new GuzzleHttpClient($options);
     }
 
@@ -250,5 +254,8 @@ class Client
 
         return $resource;
     }
-
+    public function setProxy($proxy)
+    {
+        $this->proxy = $proxy;
+    }
 }


### PR DESCRIPTION
### Summary:
This PR introduces the ability to set a proxy for the `Client` class in the TikTok Shop PHP SDK. This enhancement provides flexibility for users who need to route their API requests through a proxy.

### Changes:
1. Extended the `Client` class constructor to accept an optional proxy parameter.
2. Added a `setProxy` method to the `Client` class to allow setting the proxy after initialization.
3. Modified the `httpClient` method to utilize the proxy setting when creating the Guzzle HTTP client.

### Use Case:
This feature is particularly useful for developers working behind a corporate firewall or those who want to route their requests through specific geographic locations for testing purposes.

### Testing:
1. Initialized the `Client` with a proxy and made API requests to verify they are routed through the proxy.
2. Used the `setProxy` method to change the proxy and verified the subsequent requests are routed through the new proxy.

Please review and let me know if there are any concerns or changes needed.
