### PR TITLE
Unset "shop_cipher" from "Create Custom Brands" request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -173,6 +173,7 @@ class Client
 
         // shop_cipher is not allowed in some api
         if (preg_match('/^\/product\/(\d{6})\/(global_products|files\/upload|images\/upload)/', $uri->getPath())
+            || ($request->getMethod() === 'POST' && preg_match('/^\/product\/(\d{6})\/(brands)/', $uri->getPath()))
             || preg_match('/^\/(authorization|seller)\/(\d{6})\//', $uri->getPath())) {
             unset($query['shop_cipher']);
         }


### PR DESCRIPTION
Hello, and thank you for the library!

When I tried to `createCustomBrand($name)`, I got an error with the message `shop_cipher is not allowed in this api`.  I see there's already a condition for that in the Client: https://github.com/EcomPHP/tiktokshop-php/blob/b9564e2bd184c47df5fb201e6a02ba930d35acbf/src/Client.php#L175-L178

This PR unsets `shop_cipher` when POST'ing to that endpoint. The GET one still needs it following the documentation:
- [Get Brands](https://partner.tiktokshop.com/docv2/page/6503075656e2bb0289dd5d01)
- [Create Custom Brands](https://partner.tiktokshop.com/docv2/page/650a0926f1fd3102b91bbfb0)

Regards,
Álvaro